### PR TITLE
Fix issue using this package with build tool like vitejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/iban-ts.esm.js",
   "typings": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/iban-ts.esm.js",


### PR DESCRIPTION
Using this package in a project using vitejs, I get the following error : 

```
unexpected token 'export'
```

This is because we import esm build but we do not have the "type: module" set in package.json so it is treated as a CJS module instead of an ES module.
This PR fix this issue.